### PR TITLE
Test for AsyncCreatable

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  setupFilesAfterEnv: ["@testing-library/react/cleanup-after-each"],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/romgain/react-select-event#readme",
   "dependencies": {
-    "@testing-library/dom": "^5.5.2"
+    "@testing-library/dom": "^6.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -46,14 +46,14 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
     "@testing-library/jest-dom": "^4.0.0",
-    "@testing-library/react": "^8.0.4",
+    "@testing-library/react": "^9.1.3",
     "@types/jest": "^24.0.13",
     "@types/react": "^16.8.19",
     "@types/react-select": "^2.0.19",
     "jest": "^24.8.0",
     "prettier": "^1.17.1",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
     "react-select": "^2.4.3",
     "rimraf": "^2.6.3",
     "rollup": "^1.12.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/romgain/react-select-event#readme",
   "dependencies": {
-    "@testing-library/dom": "^6.1.0"
+    "@testing-library/dom": ">=5"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export const select = async (
  * @param input The input field (eg. `getByLabelText('The label')`)
  * @param option The display name for the option to type and select
  */
-export const create = (input: HTMLElement, option: string) => {
+export const create = async (input: HTMLElement, option: string) => {
   focus(input);
   type(input, option);
   // hit Enter to add the item
@@ -59,6 +59,7 @@ export const create = (input: HTMLElement, option: string) => {
     keyCode: 13,
     code: 13
   });
+  await findByText(getReactSelectContainerFromInput(input), option);
 };
 
 /**


### PR DESCRIPTION
Hello again! I found something interesting related to my original issue https://github.com/romgain/react-select-event/issues/4

It looks like `selectEvent.create` isn't working fine for async creatable. I'm creating this PR just to show you the changes I made, not expecting to be merged to be honest.

I had some issues when creating a new option using AsyncCreatable component and passing `onCreateOption` callback (I'm not sure if the `onCreateOption` callback is 100% related, but just in case).

If I use `selectEvent.create` the `onCreateOption` is never called, while it is called if I type the new option and select option for creating manually. Note the `await wait()` for waiting the option creation process.

I've updated React and RTL dependencies, as latest versions for both improve async stuff when testing, but it didn't fix it (tho I think is a good idea to upgrade them).

Again, I don't know if I'm doing something wrong here, but I can't find better way to solve this.