### PR TITLE
AsyncCreatable bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This library is tested against all versions of `react-select` starting from `2.1
 
 Every helper exported by `react-select-event` takes a handle on the `react-select` input field as its first argument. For instance, this can be: `getByLabelText("Your label name")`.
 
-### `select(input: HTMLElement, optionOrOptions: string | Array<string>): Promise<void>`
+### `select(input: HTMLElement, optionOrOptions: string | RegExp | Array<string | RegExp>): Promise<void>`
 
 Select one or more values in a react-select dropdown.
 
@@ -85,7 +85,7 @@ expect(getByTestId("form")).toHaveFormValues({
 });
 ```
 
-### `create(input: HTMLElement, option: string): void`
+### `create(input: HTMLElement, option: string, createOptionText: string | RegExp = /^Create "/): Promise<void>`
 
 Creates and selects a new item. Only applicable to `react-select` [`Creatable`](https://react-select.com/creatable) elements.
 
@@ -100,6 +100,8 @@ expect(getByTestId("form")).toHaveFormValues({ food: "" });
 await selectEvent.create(getByLabelText("Food"), "papaya");
 expect(getByTestId("form")).toHaveFormValues({ food: "papaya" });
 ```
+
+`create` take a third, optional parameter, only necessary when [creating elements with a custom label text, using the `formatCreateLabel` prop](https://react-select.com/props#creatable-props).
 
 ### `clearFirst(input: HTMLElement): void`
 

--- a/src/__tests__/select-event.test.tsx
+++ b/src/__tests__/select-event.test.tsx
@@ -78,6 +78,48 @@ describe("The select event helpers", () => {
     expect(form).toHaveFormValues({ food: "papaya" });
   });
 
+  it("types in and add a new option with custom create label when searching by fixed string", async () => {
+    const { form, input } = renderForm(
+      <Creatable
+        {...defaultProps}
+        formatCreateLabel={() => "Add new option"}
+      />
+    );
+    expect(form).toHaveFormValues({ food: "" });
+
+    await selectEvent.create(input, "papaya", "Add new option");
+
+    expect(form).toHaveFormValues({ food: "papaya" });
+  });
+
+  it("types in and add a new option with custom create label when searching by dynamic string", async () => {
+    const { form, input } = renderForm(
+      <Creatable
+        {...defaultProps}
+        formatCreateLabel={(inputValue: string) => inputValue}
+      />
+    );
+    expect(form).toHaveFormValues({ food: "" });
+
+    await selectEvent.create(input, "papaya", "papaya");
+
+    expect(form).toHaveFormValues({ food: "papaya" });
+  });
+
+  it("types in and add a new option with custom create label when searching by regexp", async () => {
+    const { form, input } = renderForm(
+      <Creatable
+        {...defaultProps}
+        formatCreateLabel={(inputValue: string) => `Generate new option "${inputValue}"`}
+      />
+    );
+    expect(form).toHaveFormValues({ food: "" });
+
+    await selectEvent.create(input, "papaya", /Generate/);
+
+    expect(form).toHaveFormValues({ food: "papaya" });
+  });
+
   it("types in and add several options", async () => {
     const { form, input } = renderForm(<Creatable {...defaultProps} isMulti />);
     expect(form).toHaveFormValues({ food: "" });
@@ -163,23 +205,26 @@ describe("The select event helpers", () => {
     });
   });
 
-  describe('AsyncCreatable', () => {
+  describe("AsyncCreatable", () => {
     // from https://github.com/JedWatson/react-select/blob/v3.0.0/docs/examples/CreatableAdvanced.js
     // mixed with Async Creatable Example from https://react-select.com/creatable
     type State = { options: Options; value: Option | void; isLoading: boolean };
 
     const filterOptions = (options: Options, inputValue: string) => {
-      return options.filter(i => i.label.toLowerCase().includes(inputValue.toLowerCase()))
+      return options.filter(i =>
+        i.label.toLowerCase().includes(inputValue.toLowerCase())
+      );
     };
 
     class CreatableAdvanced extends React.Component<{}, State> {
       state = { isLoading: false, options: OPTIONS, value: undefined };
 
-      handlePromiseOptions = (inputValue: string) => new Promise(resolve => {
-        setTimeout(() => {
-          resolve(filterOptions(this.state.options, inputValue))
-        }, 5);
-      });
+      handlePromiseOptions = (inputValue: string) =>
+        new Promise(resolve => {
+          setTimeout(() => {
+            resolve(filterOptions(this.state.options, inputValue));
+          }, 5);
+        });
 
       handleChange = (newValue: Option) => this.setState({ value: newValue });
 
@@ -199,22 +244,24 @@ describe("The select event helpers", () => {
       render() {
         const { isLoading, value } = this.state;
         return (
-            <AsyncCreatable
-                {...this.props}
-                isClearable
-                isDisabled={isLoading}
-                isLoading={isLoading}
-                onChange={this.handleChange}
-                onCreateOption={this.handleCreate}
-                loadOptions={this.handlePromiseOptions}
-                value={value}
-            />
+          <AsyncCreatable
+            {...this.props}
+            isClearable
+            isDisabled={isLoading}
+            isLoading={isLoading}
+            onChange={this.handleChange}
+            onCreateOption={this.handleCreate}
+            loadOptions={this.handlePromiseOptions}
+            value={value}
+          />
         );
       }
     }
 
     it("types in and adds a new option when having similar options", async () => {
-      const { form, input } = renderForm(<CreatableAdvanced {...defaultProps} />);
+      const { form, input } = renderForm(
+        <CreatableAdvanced {...defaultProps} />
+      );
 
       await selectEvent.create(input, "Choco");
       await wait();
@@ -223,7 +270,9 @@ describe("The select event helpers", () => {
     });
 
     it("types in and adds a new option when not having similar options", async () => {
-      const { form, input } = renderForm(<CreatableAdvanced {...defaultProps} />);
+      const { form, input } = renderForm(
+        <CreatableAdvanced {...defaultProps} />
+      );
 
       await selectEvent.create(input, "papaya");
       await wait();

--- a/src/__tests__/select-event.test.tsx
+++ b/src/__tests__/select-event.test.tsx
@@ -214,21 +214,19 @@ describe("The select event helpers", () => {
     }
 
     it("types in and adds a new option when having similar options", async () => {
-      const { form, input, debug } = renderForm(<CreatableAdvanced {...defaultProps} />);
+      const { form, input } = renderForm(<CreatableAdvanced {...defaultProps} />);
 
       await selectEvent.create(input, "Choco");
       await wait();
-      debug();
 
       expect(form).toHaveFormValues({ food: "Choco" });
     });
 
     it("types in and adds a new option when not having similar options", async () => {
-      const { form, input, debug } = renderForm(<CreatableAdvanced {...defaultProps} />);
+      const { form, input } = renderForm(<CreatableAdvanced {...defaultProps} />);
 
       await selectEvent.create(input, "papaya");
       await wait();
-      debug();
 
       expect(form).toHaveFormValues({ food: "papaya" });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const type = (input: HTMLElement, text: string) => {
  */
 export const select = async (
   input: HTMLElement,
-  optionOrOptions: string | Array<string>
+  optionOrOptions: string | RegExp | Array<string | RegExp>
 ) => {
   const options = Array.isArray(optionOrOptions)
     ? optionOrOptions
@@ -47,18 +47,18 @@ export const select = async (
 
 /**
  * Utility for creating and selecting a value in a Creatable `react-select` dropdown.
+ * @async
  * @param input The input field (eg. `getByLabelText('The label')`)
  * @param option The display name for the option to type and select
+ * @param createOptionText Custom label for the "create new ..." option in the menu (string or regexp)
  */
-export const create = async (input: HTMLElement, option: string) => {
+export const create = async (input: HTMLElement, option: string, createOptionText: string | RegExp = /^Create "/) => {
   focus(input);
   type(input, option);
-  // hit Enter to add the item
-  fireEvent.keyDown(input, {
-    key: "Enter",
-    keyCode: 13,
-    code: 13
-  });
+
+  fireEvent.change(input, { target: { value: option } });
+  await select(input, createOptionText);
+
   await findByText(getReactSelectContainerFromInput(input), option);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 /** Simulate user events on react-select dropdowns */
 
-import { fireEvent, findByText, getByText } from "@testing-library/dom";
+import {
+  fireEvent,
+  findByText,
+  getByText,
+  findAllByText
+} from "@testing-library/dom";
 
 // find the react-select container from its input field 🤷
 function getReactSelectContainerFromInput(input: HTMLElement): HTMLElement {
@@ -40,8 +45,9 @@ export const select = async (
   // Select the items we care about
   for (const option of options) {
     focus(input);
-    await findByText(container, option);
-    fireEvent.click(getByText(container, option));
+    const elementsMatchingText = await findAllByText(container, option);
+    const optionContainer = elementsMatchingText[elementsMatchingText.length - 1];
+    fireEvent.click(getByText(optionContainer, option));
   }
 };
 
@@ -52,7 +58,11 @@ export const select = async (
  * @param option The display name for the option to type and select
  * @param createOptionText Custom label for the "create new ..." option in the menu (string or regexp)
  */
-export const create = async (input: HTMLElement, option: string, createOptionText: string | RegExp = /^Create "/) => {
+export const create = async (
+  input: HTMLElement,
+  option: string,
+  createOptionText: string | RegExp = /^Create "/
+) => {
   focus(input);
   type(input, option);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
 /** Simulate user events on react-select dropdowns */
 
-import {
-  fireEvent,
-  findByText,
-  getByText,
-  findAllByText
-} from "@testing-library/dom";
+import { fireEvent, findByText } from "@testing-library/dom";
 
 // find the react-select container from its input field 🤷
 function getReactSelectContainerFromInput(input: HTMLElement): HTMLElement {
@@ -45,9 +40,13 @@ export const select = async (
   // Select the items we care about
   for (const option of options) {
     focus(input);
-    const elementsMatchingText = await findAllByText(container, option);
-    const optionContainer = elementsMatchingText[elementsMatchingText.length - 1];
-    fireEvent.click(getByText(optionContainer, option));
+
+    // only consider accessible elements
+    const optionElement = await findByText(container, option, {
+      // @ts-ignore invalid rtl types :'(
+      ignore: ":not([tabindex])"
+    });
+    fireEvent.click(optionElement);
   }
 };
 


### PR DESCRIPTION
Hello again, I'm back!

I just realized today that when you fixed an async problem for AsyncCreatable in https://github.com/romgain/react-select-event/pull/5 it wasn't completely fixed.

In your test you were using the AsyncCreatable but not with proper set up: this component is meant to be used with `loadOptions` promise instead of just `options` array.

So I have updated the CreatableAdvanced component you added for testing purposes with proper async load options from [Async Creatable example](https://react-select.com/creatable) and then generate two different tests: one where the entered text to be created has a similar existing option and another one when it doesn't have any similar option.

Both of them fail, though I assumed just first one would fail:

1. When having similar option for creating a new one, the `create` util is just focusing, typing and pressing enter so it's assuming the 'Create "whatever"' is always the first option! You can see on the debug of the first test that first option is 'Chocolate' and the second one is 'Create "Choco"' so `create` util has to be improved to find proper creating option within the dropdown (can't assume it will be the last one, as user can configure on react-select if they want to see it at first or last position, neither find it by 'Create' prefix as it's customizable).
2. I'm not sure why the second test is failing, as the only available option for that one is to actually create papaya, so probably there is more async stuff that `create` util has to handle.

I don't have time at the moment to keep investigating, but I leave you this here so you can check it deeper!