### PR TITLE
Name the default export `selectEvent` 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,4 +125,5 @@ export const clearAll = async (input: HTMLElement) => {
   await clear(input, clearAllButton);
 };
 
-export default { select, create, clearFirst, clearAll, openMenu };
+const selectEvent = { select, create, clearFirst, clearAll, openMenu };
+export default selectEvent;


### PR DESCRIPTION
Enable IDE to auto-import it more easily

Previously if you were to type "selectEvent" IDEs like WebStorm would not be able to
help with auto-importing the object into the file. This gives it a hint.