### PR TITLE
fix: remove already ignored files and ignore src

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,14 @@
 .babelrc
-.git
 .gitignore
 .npmignore
-.npmrc
 .prettierrc
 .tav.yml
 .travis.yml
 *.tgz
 coverage
 jest.config.js
-node_modules
 other
 rollup.config.js
+src
 tsconfig.build.json
 tsconfig.json


### PR DESCRIPTION
Some of the files in the npmignore file are ignored automatically.

Ignore the src directory so it isn't published as its unneeded space