### PR TITLE
Fix for autoSelect not implemented correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ expect(getByRole("form")).toHaveFormValues({ food: "papaya" });
 `create` take an optional `config` parameter:
 
 - `config.createOptionText` can be used when [creating elements with a custom label text, using the `formatCreateLabel` prop](https://react-select.com/props#creatable-props).
-- `config.autoSelect` is used to automatically select the newly created option, it defaults to `true`.
 - `config.container` can be used when the `react-select` dropdown is rendered in a portal using `menuPortalTarget`.
+- `config.waitForElement` Whether `create` should wait for new option to be populated in the select container. Defaults to `true`.
 
 ### `clearFirst(input: HTMLElement): Promise<void>`
 

--- a/src/__tests__/select-event.test.tsx
+++ b/src/__tests__/select-event.test.tsx
@@ -127,11 +127,11 @@ describe("The select event helpers", () => {
     expect(form).toHaveFormValues({ food: "papaya" });
   });
 
-  it("types in and adds a new option but does not select it by default", async () => {
+  it("types in and adds a new option but does not wait for it", async () => {
     const { form, input } = renderForm(<Creatable {...defaultProps} />);
     expect(form).toHaveFormValues({ food: "" });
-    await selectEvent.create(input, "papaya", { autoSelect: false });
-    expect(form).toHaveFormValues({ food: "" });
+    await selectEvent.create(input, "papaya", { waitForElement: false });
+    expect(form).toHaveFormValues({ food: "papaya" });
   });
 
   it("types in and adds a new option with custom create label when searching by fixed string", async () => {
@@ -383,18 +383,6 @@ describe("The select event helpers", () => {
       expect(form).toHaveFormValues({ food: "" });
       await selectEvent.create(input, "papaya", { container: document.body });
       expect(form).toHaveFormValues({ food: "papaya" });
-    });
-
-    it("types in and adds a new option but does not select it by default", async () => {
-      const { form, input } = renderForm(
-        <Creatable {...defaultProps} menuPortalTarget={document.body} />
-      );
-      expect(form).toHaveFormValues({ food: "" });
-      await selectEvent.create(input, "papaya", {
-        autoSelect: false,
-        container: document.body,
-      });
-      expect(form).toHaveFormValues({ food: "" });
     });
 
     it("clears the first item in a multi-select dropdown", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,8 +84,8 @@ export const select = async (
 };
 
 interface CreateConfig extends Config {
-  autoSelect?: boolean;
   createOptionText?: string | RegExp;
+  waitForElement?: boolean;
 }
 /**
  * Utility for creating and selecting a value in a Creatable `react-select` dropdown.
@@ -95,13 +95,13 @@ interface CreateConfig extends Config {
  * @param {Object} config Optional config options
  * @param {HTMLElement} config.container A container for the react-select and its dropdown (defaults to the react-select container)
  *                         Useful when rending the dropdown to a portal using react-select's `menuPortalTarget`
- * @param {boolean} config.autoSelect Whether to automatically select the newly created option or not
+ * @param {boolean} config.waitForElement Whether create should wait for new option to be populated in the select container
  * @param {String|RegExp} config.createOptionText Custom label for the "create new ..." option in the menu (string or regexp)
  */
 export const create = async (
   input: HTMLElement,
   option: string,
-  { autoSelect = true, ...config }: CreateConfig = {}
+  { waitForElement = true, ...config }: CreateConfig = {}
 ) => {
   const createOptionText = config.createOptionText || /^Create "/;
   openMenu(input);
@@ -109,8 +109,9 @@ export const create = async (
 
   fireEvent.change(input, { target: { value: option } });
 
-  if (autoSelect) {
-    await select(input, createOptionText, config);
+  await select(input, createOptionText, config);
+
+  if (waitForElement) {
     await findByText(getReactSelectContainerFromInput(input), option);
   }
 };


### PR DESCRIPTION
This is piggybacking off of issue #35 and pull request #36.

The implementation in #36 doesn't work as expected.  Regardless, I believe `await select(input, createOptionText, config);` should happen.  If I understand the code correctly, calling `await select(...)` is mimicking the user clicking `Create: "[whatever they entered]"`. I want the interaction of clicking create to happen, but when the create fails on the backend, I don't want this library to then try and find the new value (`findByText`) in the select menu because it shouldn't exist.  I'm actually a little lost as to what purpose `findByText` serves in this context.  Is it just to act as a check that the new option is in the select menu since it'll throw an exception if it doesn't exist?  If so, that check seems more fitting to be in the unit tests than in `index.ts`.

Link to commit that intorduced `findByText`: https://github.com/romgain/react-select-event/commit/83cf114ff903a05528318574aeb3cdd3c5f02b7a