### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ const { getByLabelText, queryByText } = render(
 );
 expect(queryByText("Pizza")).toBeNull();
 selectEvent.openMenu(getByLabelText("Food"));
-expect(queryByText("Pizza")).toBeInTheDocument();
+expect(getByText("Pizza")).toBeInTheDocument();
 ```
 
 ## Credits


### PR DESCRIPTION
Must to be getBytext because is in the document queryBy*** is for not tobe in the document According to https://testing-library.com/docs/dom-testing-library/api-queries