### PR TITLE
5.1.0 changes wrong input when using querySelector and multiple select

### DIFF
--- a/src/__tests__/select-event.test.tsx
+++ b/src/__tests__/select-event.test.tsx
@@ -290,6 +290,32 @@ describe("The select event helpers", () => {
     expect(form).toHaveFormValues({ food: "vanilla" });
   });
 
+  it("selects options when there are multiple dropdowns", async () => {
+    const {container, getByRole} = render(
+      <form role="form">
+        <label htmlFor="food-for-monday">Food for monday</label>
+        <Select
+          options={OPTIONS} name="foodForMonday" inputId="food-for-monday"
+          formatOptionLabel={({ label }) => <div>This is a {label}</div>}
+        />
+        <label htmlFor="food-for-tuesday">Food for tuesday</label>
+        <Select
+          options={OPTIONS} name="foodForTuesday" inputId="food-for-tuesday"
+          formatOptionLabel={({ label }) => <div>This is a {label}</div>}
+        />
+      </form>
+    );
+    const form = getByRole("form");
+    // const mondayInput = result.getByLabelText("Food for monday");
+    const mondayInput = container.querySelector('input[name="foodForMonday"]')
+    const tuesdayInput = container.querySelector('input[name="foodForTuesday"]')
+
+    expect(form).toHaveFormValues({ foodForMonday: "", foodForTuesday: "" });
+    await selectEvent.select(mondayInput, /Chocolate/);
+    await selectEvent.select(tuesdayInput, /Chocolate/);
+    expect(form).toHaveFormValues({ foodForMonday: "chocolate", foodForTuesday: "chocolate" });
+  });
+
   describe("when asynchronously generating the list of options", () => {
     // from https://github.com/JedWatson/react-select/blob/v3.0.0/docs/examples/CreatableAdvanced.js
     // mixed with Async Creatable Example from https://react-select.com/creatable

--- a/src/__tests__/select-event.test.tsx
+++ b/src/__tests__/select-event.test.tsx
@@ -306,7 +306,6 @@ describe("The select event helpers", () => {
       </form>
     );
     const form = getByRole("form");
-    // const mondayInput = result.getByLabelText("Food for monday");
     const mondayInput = container.querySelector('input[name="foodForMonday"]')
     const tuesdayInput = container.querySelector('input[name="foodForTuesday"]')
 


### PR DESCRIPTION
Since 5.1.0, using querySelector fails when having multiple inputs with the same options.
`.select` will change the first select that have the option available.

I couldn't debug it, but here's a test case hoping it will help.

Thank you for the awesome work and have a nice day!