### PR TITLE
Dynamically get react-select parent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@ function getReactSelectContainerFromInput(input: HTMLElement): HTMLElement {
 
   // for older versions of react-select fall back to old parent crawler
   if (!parent) {
-    console.log("index:19", "legacy crawler");
     parent = input.parentNode!.parentNode!.parentNode!.parentNode!
       .parentNode as HTMLElement;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 /** Simulate user events on react-select dropdowns */
 
 import {
-  Matcher,
   findAllByText,
   findByText,
   fireEvent,
+  Matcher,
   waitFor,
 } from "@testing-library/dom";
 
@@ -12,7 +12,19 @@ import act from "./act-compat";
 
 // find the react-select container from its input field 🤷
 function getReactSelectContainerFromInput(input: HTMLElement): HTMLElement {
-    return input.closest('[class^="css-"], [class$="-container"]') as HTMLElement;
+  // i hate this so much but older versions insist on inserting a space before their generated class name
+  let parent =
+    input.closest('[class^="css-"][class$="-container"]') ||
+    input.closest('[class^=" css-"][class$="-container"]');
+
+  // for older versions of react-select fall back to old parent crawler
+  if (!parent) {
+    console.log("index:19", "legacy crawler");
+    parent = input.parentNode!.parentNode!.parentNode!.parentNode!
+      .parentNode as HTMLElement;
+  }
+
+  return parent as HTMLElement;
 }
 
 /**
@@ -104,6 +116,7 @@ interface CreateConfig extends Config {
   createOptionText?: string | RegExp;
   waitForElement?: boolean;
 }
+
 /**
  * Utility for creating and selecting a value in a Creatable `react-select` dropdown.
  * @async

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,7 @@ import act from "./act-compat";
 
 // find the react-select container from its input field 🤷
 function getReactSelectContainerFromInput(input: HTMLElement): HTMLElement {
-  return input.parentNode!.parentNode!.parentNode!.parentNode!
-    .parentNode as HTMLElement;
+    return input.closest('[class^="css-"], [class$="-container"]') as HTMLElement;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ function getReactSelectContainerFromInput(input: HTMLElement): HTMLElement {
     input.closest('[class^=" css-"][class$="-container"]');
 
   // for older versions of react-select fall back to old parent crawler
+  // istanbul ignore if
   if (!parent) {
     parent = input.parentNode!.parentNode!.parentNode!.parentNode!
       .parentNode as HTMLElement;


### PR DESCRIPTION
Get react-select parent using .closest and attribute matchers to match dynamically generated class ex: `.css-ab123s-container`