### PR TITLE
Chore: Move @testing-library/dom to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-select-event",
-  "version": "5.5.2",
+  "version": "5.5.1",
   "description": "Simulate react-select events for react-testing-library",
   "main": "lib/react-select-event.cjs.js",
   "module": "lib/react-select-event.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-select-event",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "Simulate react-select events for react-testing-library",
   "main": "lib/react-select-event.cjs.js",
   "module": "lib/react-select-event.es.js",
@@ -35,7 +35,7 @@
     "url": "https://github.com/romgain/react-select-event/issues"
   },
   "homepage": "https://github.com/romgain/react-select-event#readme",
-  "dependencies": {
+  "peerDependencies": {
     "@testing-library/dom": ">=7"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR makes `@testing-library/dom` a `peerDependency` allowing projects to define the version of the package they require. I tested this by building and publishing locally and after install tests continued to run.

Fixes: #70 