### PR TITLE
Cannot select same option for multiple dropdowns

### DIFF
--- a/src/__tests__/select-event.test.tsx
+++ b/src/__tests__/select-event.test.tsx
@@ -344,6 +344,42 @@ describe("The select event helpers", () => {
     expect(form).toHaveFormValues({ food: "vanilla" });
   });
 
+  it("selects same options on multiple dropdowns", async () => {
+    const { getByLabelText, getByRole } = render(
+      <form role="form">
+        <label htmlFor="food-for-monday">Food for monday</label>
+        <Select
+          options={OPTIONS}
+          name="foodForMonday"
+          inputId="food-for-monday"
+        />
+        <label htmlFor="food-for-tuesday">Food for tuesday</label>
+        <Select
+          options={OPTIONS}
+          name="foodForTuesday"
+          inputId="food-for-tuesday"
+        />
+      </form>
+    );
+    const form = getByRole("form");
+    const mondayInput = getByLabelText("Food for monday");
+    const tuesdayInput = getByLabelText("Food for tuesday");
+
+    expect(form).toHaveFormValues({ foodForMonday: "", foodForTuesday: "" });
+
+    await selectEvent.select(tuesdayInput, "Chocolate");
+    expect(form).toHaveFormValues({
+      foodForMonday: "",
+      foodForTuesday: "chocolate",
+    });
+
+    await selectEvent.select(mondayInput, "Chocolate");
+    expect(form).toHaveFormValues({
+      foodForMonday: "chocolate",
+      foodForTuesday: "chocolate",
+    });
+  });
+
   describe("when asynchronously generating the list of options", () => {
     // from https://github.com/JedWatson/react-select/blob/v3.0.0/docs/examples/CreatableAdvanced.js
     // mixed with Async Creatable Example from https://react-select.com/creatable


### PR DESCRIPTION
It fails to select the same option when there is multiple dropdowns.

It seems that `getReactSelectContainerFromInput` goes to far in the ancestor tree. When trying to click on the option, it sees the text from the other dropdown.